### PR TITLE
Make sure volume selectId parsed back to int

### DIFF
--- a/templates/volume_tab.html
+++ b/templates/volume_tab.html
@@ -502,7 +502,7 @@
       volumeDataTable.on('change', 'select', function hostChanged () {
         var selectId = $(this).attr('id');
         //Note : id is stored as part of the select element id E.g. primary_host_<id>
-        var id = selectId.split('_').pop();
+        var id = parseInt(selectId.split('_').pop());
 
         var volumes = volumeDataTable.fnGetData();
         var volumeFinder = getVolumeFinder(volumes);


### PR DESCRIPTION
When we updated tastypie, the ID's switched from being strings to ints over the wire.

As such, we need to make sure all comparisons are done with ints.